### PR TITLE
Give instructions on using GraphQL::Batch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ This will cache the entire response when the query includes `FIELDS`.
 These are all based off of community-written examples using [graphql-batch](https://github.com/Shopify/graphql-batch).
 These will reduce N+1 queries in your GraphQL code.
 
+Before using loaders, you'll have to [use `GraphQL::Batch`](https://github.com/Shopify/graphql-batch#basic-usage) as a plugin in your schema:
+
+``` ruby
+YourSchema = GraphQL::Schema.define do
+  query YourQueryType
+
+  use GraphQL::Batch
+end
+```
+
 Batch up `belongs_to` calls:
 
 ``` ruby


### PR DESCRIPTION
It might make sense to provide a `CacheQL` plugin that delegates to `GraphQL::Batch` for future extensibility. e.g. if you wanted to provide additional functionality in this gem without people having to update which plugin they were using.

For now though, this is necessary to get loaders working.